### PR TITLE
Re-use codebase from single iCal event export

### DIFF
--- a/controllers/EntryController.php
+++ b/controllers/EntryController.php
@@ -228,6 +228,6 @@ class EntryController extends ContentContainerController
     public function actionDownloadics()
     {
         $calendarEntry = $this->getCalendarEntry(Yii::$app->request->get('id'));
-        return $calendarEntry->DownloadIcs();
+        return $calendarEntry->downloadIcs();
     }
 }

--- a/controllers/EntryController.php
+++ b/controllers/EntryController.php
@@ -224,4 +224,10 @@ class EntryController extends ContentContainerController
     {
         return $this->contentContainer->permissionManager->can(new ManageEntry);
     }
+
+    public function actionDownloadics()
+    {
+        $calendarEntry = $this->getCalendarEntry(Yii::$app->request->get('id'));
+        return $calendarEntry->DownloadIcs();
+    }
 }

--- a/controllers/EntryController.php
+++ b/controllers/EntryController.php
@@ -225,9 +225,10 @@ class EntryController extends ContentContainerController
         return $this->contentContainer->permissionManager->can(new ManageEntry);
     }
 
-    public function actionDownloadics()
+    public function actionGenerateics()
     {
         $calendarEntry = $this->getCalendarEntry(Yii::$app->request->get('id'));
-        return $calendarEntry->downloadIcs();
+        $ics = $calendarEntry->generateIcs();
+        return Yii::$app->response->sendContentAsFile($ics, uniqid() . '.ics', ['mimeType' => 'text/calendar']);
     }
 }

--- a/models/CalendarEntry.php
+++ b/models/CalendarEntry.php
@@ -671,15 +671,8 @@ class CalendarEntry extends ContentActiveRecord implements Searchable, CalendarI
         $timezone = $module->settings->get('timeZone');
         header('Content-Type: text/calendar; charset=utf-8');
         header('Content-Disposition: attachment; filename=invite.ics');
-        /*$ics = new \humhub\modules\calendar\models\ICS(array(
-            'location' => null,
-            'description' => $this->description,
-            'dtstart' => $this->start_datetime,
-            'dtend' => $this->end_datetime,
-            'summary' => $this->title,
-            'url' => null
-        ), $timeZone);*/
-        $ics = new \humhub\modules\calendar\models\ICS($this->title, $this->description, $this->start_datetime, $this->end_datetime, null, null, $timezone);
+        $ics = new \humhub\modules\calendar\models\ICS($this->title, $this->description,
+        $this->start_datetime, $this->end_datetime, null, null, $timezone);
         echo $ics->to_string();
     }
 }

--- a/models/CalendarEntry.php
+++ b/models/CalendarEntry.php
@@ -665,14 +665,11 @@ class CalendarEntry extends ContentActiveRecord implements Searchable, CalendarI
         return null;
     }
 
-    public function DownloadIcs()
+    public function downloadIcs()
     {
         $module = Yii::$app;
         $timezone = $module->settings->get('timeZone');
-        header('Content-Type: text/calendar; charset=utf-8');
-        header('Content-Disposition: attachment; filename=invite.ics');
-        $ics = new \humhub\modules\calendar\models\ICS($this->title, $this->description,
-        $this->start_datetime, $this->end_datetime, null, null, $timezone);
-        echo $ics->to_string();
+        $ics = new \humhub\modules\calendar\models\ICS($this->title, $this->description,$this->start_datetime, $this->end_datetime, null, null, $timezone);
+        return Yii::$app->response->sendContentAsFile($ics, uniqid() . '.ics', ['mimeType' => 'text/calendar']);
     }
 }

--- a/models/CalendarEntry.php
+++ b/models/CalendarEntry.php
@@ -665,11 +665,11 @@ class CalendarEntry extends ContentActiveRecord implements Searchable, CalendarI
         return null;
     }
 
-    public function downloadIcs()
+    public function generateIcs()
     {
         $module = Yii::$app;
         $timezone = $module->settings->get('timeZone');
         $ics = new \humhub\modules\calendar\models\ICS($this->title, $this->description,$this->start_datetime, $this->end_datetime, null, null, $timezone);
-        return Yii::$app->response->sendContentAsFile($ics, uniqid() . '.ics', ['mimeType' => 'text/calendar']);
+        return $ics;
     }
 }

--- a/models/CalendarEntry.php
+++ b/models/CalendarEntry.php
@@ -664,4 +664,19 @@ class CalendarEntry extends ContentActiveRecord implements Searchable, CalendarI
 
         return null;
     }
+
+    public function DownloadIcs()
+    {
+        header('Content-Type: text/calendar; charset=utf-8');
+        header('Content-Disposition: attachment; filename=invite.ics');
+        $ics = new \humhub\modules\calendar\models\ICS(array(
+            'location' => null,
+            'description' => $this->description,
+            'dtstart' => $this->start_datetime,
+            'dtend' => $this->end_datetime,
+            'summary' => $this->title,
+            'url' => null
+        ));
+        echo $ics->to_string();
+    }
 }

--- a/models/CalendarEntry.php
+++ b/models/CalendarEntry.php
@@ -667,16 +667,19 @@ class CalendarEntry extends ContentActiveRecord implements Searchable, CalendarI
 
     public function DownloadIcs()
     {
+        $module = Yii::$app;
+        $timezone = $module->settings->get('timeZone');
         header('Content-Type: text/calendar; charset=utf-8');
         header('Content-Disposition: attachment; filename=invite.ics');
-        $ics = new \humhub\modules\calendar\models\ICS(array(
+        /*$ics = new \humhub\modules\calendar\models\ICS(array(
             'location' => null,
             'description' => $this->description,
             'dtstart' => $this->start_datetime,
             'dtend' => $this->end_datetime,
             'summary' => $this->title,
             'url' => null
-        ));
+        ), $timeZone);*/
+        $ics = new \humhub\modules\calendar\models\ICS($this->title, $this->description, $this->start_datetime, $this->end_datetime, null, null, $timezone);
         echo $ics->to_string();
     }
 }

--- a/models/ICS.php
+++ b/models/ICS.php
@@ -1,0 +1,134 @@
+<?php
+
+/**
+* https://gist.github.com/jakebellacera/635416
+ * ICS.php
+ * =======
+ * Use this class to create an .ics file.
+ *
+ * Usage
+ * -----
+ * Basic usage - generate ics file contents (see below for available properties):
+ *   $ics = new ICS($props);
+ *   $ics_file_contents = $ics->to_string();
+ *
+ * Setting properties after instantiation
+ *   $ics = new ICS();
+ *   $ics->set('summary', 'My awesome event');
+ *
+ * You can also set multiple properties at the same time by using an array:
+ *   $ics->set(array(
+ *     'dtstart' => 'now + 30 minutes',
+ *     'dtend' => 'now + 1 hour'
+ *   ));
+ *
+ * Available properties
+ * --------------------
+ * description
+ *   String description of the event.
+ * dtend
+ *   A date/time stamp designating the end of the event. You can use either a
+ *   DateTime object or a PHP datetime format string (e.g. "now + 1 hour").
+ * dtstart
+ *   A date/time stamp designating the start of the event. You can use either a
+ *   DateTime object or a PHP datetime format string (e.g. "now + 1 hour").
+ * location
+ *   String address or description of the location of the event.
+ * summary
+ *   String short summary of the event - usually used as the title.
+ * url
+ *   A url to attach to the the event. Make sure to add the protocol (http://
+ *   or https://).
+ */
+
+namespace humhub\modules\calendar\models;
+
+class ICS {
+  const DT_FORMAT = 'Ymd\THis\Z';
+
+  protected $properties = array();
+  private $available_properties = array(
+    'description',
+    'dtend',
+    'dtstart',
+    'location',
+    'summary',
+    'url'
+  );
+
+  public function __construct($props) {
+    $this->set($props);
+  }
+
+  public function set($key, $val = false) {
+    if (is_array($key)) {
+      foreach ($key as $k => $v) {
+        $this->set($k, $v);
+      }
+    } else {
+      if (in_array($key, $this->available_properties)) {
+        $this->properties[$key] = $this->sanitize_val($val, $key);
+      }
+    }
+  }
+
+  public function to_string() {
+    $rows = $this->build_props();
+    return implode("\r\n", $rows);
+  }
+
+  private function build_props() {
+    // Build ICS properties - add header
+    $ics_props = array(
+      'BEGIN:VCALENDAR',
+      'VERSION:2.0',
+      'PRODID:-//hacksw/handcal//NONSGML v1.0//EN',
+      'CALSCALE:GREGORIAN',
+      'BEGIN:VEVENT'
+    );
+
+    // Build ICS properties - add header
+    $props = array();
+    foreach($this->properties as $k => $v) {
+      $props[strtoupper($k . ($k === 'url' ? ';VALUE=URI' : ''))] = $v;
+    }
+
+    // Set some default values
+    $props['DTSTAMP'] = $this->format_timestamp('now');
+    $props['UID'] = uniqid();
+
+    // Append properties
+    foreach ($props as $k => $v) {
+      $ics_props[] = "$k:$v";
+    }
+
+    // Build ICS properties - add footer
+    $ics_props[] = 'END:VEVENT';
+    $ics_props[] = 'END:VCALENDAR';
+
+    return $ics_props;
+  }
+
+  private function sanitize_val($val, $key = false) {
+    switch($key) {
+      case 'dtend':
+      case 'dtstamp':
+      case 'dtstart':
+        $val = $this->format_timestamp($val);
+        break;
+      default:
+        $val = $this->escape_string($val);
+    }
+
+    return $val;
+  }
+
+  private function format_timestamp($timestamp) {
+    $dt = new \DateTime($timestamp);
+    return $dt->format(self::DT_FORMAT);
+  }
+
+  private function escape_string($str) {
+    return preg_replace('/([\,;])/','\\\$1', $str);
+  }
+}

--- a/models/ICS.php
+++ b/models/ICS.php
@@ -44,32 +44,23 @@
 namespace humhub\modules\calendar\models;
 
 class ICS {
-  const DT_FORMAT = 'Ymd\THis\Z';
+  const DT_FORMAT = 'Ymd\THis';
+  protected $summary;
+  protected $description;
+  protected $dtstart;
+  protected $dtend;
+  protected $location;
+  protected $url;
+  protected $timezone;
 
-  protected $properties = array();
-  private $available_properties = array(
-    'description',
-    'dtend',
-    'dtstart',
-    'location',
-    'summary',
-    'url'
-  );
-
-  public function __construct($props) {
-    $this->set($props);
-  }
-
-  public function set($key, $val = false) {
-    if (is_array($key)) {
-      foreach ($key as $k => $v) {
-        $this->set($k, $v);
-      }
-    } else {
-      if (in_array($key, $this->available_properties)) {
-        $this->properties[$key] = $this->sanitize_val($val, $key);
-      }
-    }
+  public function __construct($summary, $description, $dtstart, $dtend, $location, $url, $timezone) {
+    $this->summary = $this->escape_string($summary);
+    $this->description = $this->escape_string($description);
+    $this->dtstart = $this->format_timestamp($dtstart);
+    $this->dtend = $this->format_timestamp($dtend);
+    $this->location = $this->escape_string($location);
+    $this->url = $this->escape_string($url);
+    $this->timezone = $timezone;
   }
 
   public function to_string() {
@@ -78,49 +69,26 @@ class ICS {
   }
 
   private function build_props() {
+
     // Build ICS properties - add header
     $ics_props = array(
       'BEGIN:VCALENDAR',
       'VERSION:2.0',
       'PRODID:-//hacksw/handcal//NONSGML v1.0//EN',
       'CALSCALE:GREGORIAN',
-      'BEGIN:VEVENT'
+      'BEGIN:VEVENT',
+      'LOCATION:' . $this->location,
+      'DESCRIPTION:' . $this->description,
+      'DTSTART;TZID=' . $this->timezone . ':' . $this->dtstart,
+      'DTEND;TZID=' . $this->timezone . ':' . $this->dtend,
+      'SUMMARY:' . $this->summary,
+      'URL:' . $this->url,
+      'DTSTAMP:' . $this->format_timestamp('now'),
+      'UID:' . uniqid(),
+      'END:VEVENT',
+      'END:VCALENDAR'
     );
-
-    // Build ICS properties - add header
-    $props = array();
-    foreach($this->properties as $k => $v) {
-      $props[strtoupper($k . ($k === 'url' ? ';VALUE=URI' : ''))] = $v;
-    }
-
-    // Set some default values
-    $props['DTSTAMP'] = $this->format_timestamp('now');
-    $props['UID'] = uniqid();
-
-    // Append properties
-    foreach ($props as $k => $v) {
-      $ics_props[] = "$k:$v";
-    }
-
-    // Build ICS properties - add footer
-    $ics_props[] = 'END:VEVENT';
-    $ics_props[] = 'END:VCALENDAR';
-
     return $ics_props;
-  }
-
-  private function sanitize_val($val, $key = false) {
-    switch($key) {
-      case 'dtend':
-      case 'dtstamp':
-      case 'dtstart':
-        $val = $this->format_timestamp($val);
-        break;
-      default:
-        $val = $this->escape_string($val);
-    }
-
-    return $val;
   }
 
   private function format_timestamp($timestamp) {

--- a/models/ICS.php
+++ b/models/ICS.php
@@ -1,102 +1,67 @@
 <?php
 
 /**
-* https://gist.github.com/jakebellacera/635416
- * ICS.php
- * =======
- * Use this class to create an .ics file.
- *
- * Usage
- * -----
- * Basic usage - generate ics file contents (see below for available properties):
- *   $ics = new ICS($props);
- *   $ics_file_contents = $ics->to_string();
- *
- * Setting properties after instantiation
- *   $ics = new ICS();
- *   $ics->set('summary', 'My awesome event');
- *
- * You can also set multiple properties at the same time by using an array:
- *   $ics->set(array(
- *     'dtstart' => 'now + 30 minutes',
- *     'dtend' => 'now + 1 hour'
- *   ));
- *
- * Available properties
- * --------------------
- * description
- *   String description of the event.
- * dtend
- *   A date/time stamp designating the end of the event. You can use either a
- *   DateTime object or a PHP datetime format string (e.g. "now + 1 hour").
- * dtstart
- *   A date/time stamp designating the start of the event. You can use either a
- *   DateTime object or a PHP datetime format string (e.g. "now + 1 hour").
- * location
- *   String address or description of the location of the event.
- * summary
- *   String short summary of the event - usually used as the title.
- * url
- *   A url to attach to the the event. Make sure to add the protocol (http://
- *   or https://).
+ *Original script: https://gist.github.com/jakebellacera/635416
  */
 
 namespace humhub\modules\calendar\models;
 
-class ICS {
-  const DT_FORMAT = 'Ymd\THis';
-  protected $summary;
-  protected $description;
-  protected $dtstart;
-  protected $dtend;
-  protected $location;
-  protected $url;
-  protected $timezone;
+class ICS
+{
+    const DT_FORMAT = 'Ymd\THis';
+    protected $summary;
+    protected $description;
+    protected $dtstart;
+    protected $dtend;
+    protected $location;
+    protected $url;
+    protected $timezone;
 
-  public function __construct($summary, $description, $dtstart, $dtend, $location, $url, $timezone) {
-    $this->summary = $this->escape_string($summary);
-    $this->description = $this->escape_string($description);
-    $this->dtstart = $this->format_timestamp($dtstart);
-    $this->dtend = $this->format_timestamp($dtend);
-    $this->location = $this->escape_string($location);
-    $this->url = $this->escape_string($url);
-    $this->timezone = $timezone;
-  }
+    public function __construct($summary, $description, $dtstart, $dtend, $location, $url, $timezone) {
+        $this->summary = $this->escapeString($summary);
+        $this->description = $this->escapeString($description);
+        $this->dtstart = $this->formatTimestamp($dtstart);
+        $this->dtend = $this->formatTimestamp($dtend);
+        $this->location = $this->escapeString($location);
+        $this->url = $this->escapeString($url);
+        $this->timezone = $timezone;
+    }
 
-  public function to_string() {
-    $rows = $this->build_props();
-    return implode("\r\n", $rows);
-  }
+    public function __toString() {
+        $rows = $this->buildProps();
+        $string =  implode("\r\n", $rows);
+        return $string;
+    }
 
-  private function build_props() {
+    private function buildProps() {
 
-    // Build ICS properties - add header
-    $ics_props = array(
-      'BEGIN:VCALENDAR',
-      'VERSION:2.0',
-      'PRODID:-//hacksw/handcal//NONSGML v1.0//EN',
-      'CALSCALE:GREGORIAN',
-      'BEGIN:VEVENT',
-      'LOCATION:' . $this->location,
-      'DESCRIPTION:' . $this->description,
-      'DTSTART;TZID=' . $this->timezone . ':' . $this->dtstart,
-      'DTEND;TZID=' . $this->timezone . ':' . $this->dtend,
-      'SUMMARY:' . $this->summary,
-      'URL:' . $this->url,
-      'DTSTAMP:' . $this->format_timestamp('now'),
-      'UID:' . uniqid(),
-      'END:VEVENT',
-      'END:VCALENDAR'
-    );
-    return $ics_props;
-  }
+        // Build ICS properties - add header
+        $ics_props = array(
+            'BEGIN:VCALENDAR',
+            'VERSION:2.0',
+            'PRODID:-//hacksw/handcal//NONSGML v1.0//EN',
+            'CALSCALE:GREGORIAN',
+            'BEGIN:VEVENT',
+            'LOCATION:' . $this->location,
+            'DESCRIPTION:' . $this->description,
+            'DTSTART;TZID=' . $this->timezone . ':' . $this->dtstart,
+            'DTEND;TZID=' . $this->timezone . ':' . $this->dtend,
+            'SUMMARY:' . $this->summary,
+            'URL:' . $this->url,
+            'DTSTAMP:' . $this->formatTimestamp('now'),
+            'UID:' . uniqid(),
+            'END:VEVENT',
+            'END:VCALENDAR'
+        );
+        return $ics_props;
+    }
 
-  private function format_timestamp($timestamp) {
-    $dt = new \DateTime($timestamp);
-    return $dt->format(self::DT_FORMAT);
-  }
+    private function formatTimestamp($timestamp) {
+        $dt = new \DateTime($timestamp);
+        return $dt->format(self::DT_FORMAT);
+    }
 
-  private function escape_string($str) {
-    return preg_replace('/([\,;])/','\\\$1', $str);
-  }
+    private function escapeString($str) {
+        return preg_replace('/([\,;])/','\\\$1', $str);
+    }
 }

--- a/models/ICS.php
+++ b/models/ICS.php
@@ -17,7 +17,8 @@ class ICS
     protected $url;
     protected $timezone;
 
-    public function __construct($summary, $description, $dtstart, $dtend, $location, $url, $timezone) {
+    public function __construct($summary, $description, $dtstart, $dtend, $location, $url, $timezone)
+    {
         $this->summary = $this->escapeString($summary);
         $this->description = $this->escapeString($description);
         $this->dtstart = $this->formatTimestamp($dtstart);
@@ -27,15 +28,15 @@ class ICS
         $this->timezone = $timezone;
     }
 
-    public function __toString() {
+    public function __toString()
+    {
         $rows = $this->buildProps();
         $string =  implode("\r\n", $rows);
         return $string;
     }
 
-    private function buildProps() {
-
-        // Build ICS properties - add header
+    private function buildProps()
+    {
         $ics_props = array(
             'BEGIN:VCALENDAR',
             'VERSION:2.0',
@@ -56,12 +57,14 @@ class ICS
         return $ics_props;
     }
 
-    private function formatTimestamp($timestamp) {
+    private function formatTimestamp($timestamp)
+    {
         $dt = new \DateTime($timestamp);
         return $dt->format(self::DT_FORMAT);
     }
 
-    private function escapeString($str) {
+    private function escapeString($str)
+    {
         return preg_replace('/([\,;])/','\\\$1', $str);
     }
 }

--- a/widgets/views/wallEntry.php
+++ b/widgets/views/wallEntry.php
@@ -71,7 +71,7 @@ $color = $calendarEntry->color ? $calendarEntry->color : $this->theme->variable(
     <?php endif; ?>
     <div class="row" style="padding-top:10px">
         <div class="col-md-12">
-            <button class='btn btn-info btn-xs' onclick='location.href="<?php echo $calendarEntry->content->container->createUrl('/calendar/entry/downloadics', ['id' => $calendarEntry->id]);?>";'>Download ICS</button>
+            <button class='btn btn-info btn-xs' onclick='location.href="<?php echo $calendarEntry->content->container->createUrl('/calendar/entry/generateics', ['id' => $calendarEntry->id]);?>";'>Download ICS</button>
         </div>
     </div>
 </div>

--- a/widgets/views/wallEntry.php
+++ b/widgets/views/wallEntry.php
@@ -69,5 +69,9 @@ $color = $calendarEntry->color ? $calendarEntry->color : $this->theme->variable(
             </div>
         </div>
     <?php endif; ?>
+    <div class="row" style="padding-top:10px">
+        <div class="col-md-12">
+            <button class='btn btn-info btn-xs' onclick='location.href="<?php echo $calendarEntry->content->container->createUrl('/calendar/entry/downloadics', ['id' => $calendarEntry->id]);?>";'>Download ICS</button>
+        </div>
+    </div>
 </div>
-


### PR DESCRIPTION
Use code from ASBaj/humhub-modules-calender as base for an export feature to export event lists in iCal format.